### PR TITLE
Fixing missing language for code fence

### DIFF
--- a/Pipelines/Azure_Container_Instances/form-recognizer-v1/README.md
+++ b/Pipelines/Azure_Container_Instances/form-recognizer-v1/README.md
@@ -6,7 +6,7 @@ The definition of the required variables are defined in `variables.tf`
 
 In order to deploy the execute
 
-```
+```bash
 terraform init
 
 terraform apply


### PR DESCRIPTION
Forgot to add language for code fence in Markdown